### PR TITLE
Depend on heroku instead of heroku-toolbelt

### DIFF
--- a/Formula/fukusu.rb
+++ b/Formula/fukusu.rb
@@ -7,7 +7,7 @@ class Fukusu < Formula
   bottle :unneeded
 
   depends_on :java => "1.7+"
-  depends_on "heroku-toolbelt"
+  depends_on "heroku"
 
   def install
     bin.install "fukusu"


### PR DESCRIPTION
The toolbelt is no longer recommended for using Heroku CLI: https://devcenter.heroku.com/articles/heroku-cli#download-and-install

(The `heroku` formula seems to be the same as using their installer.)